### PR TITLE
SW470068: Add support for enabling/disabling network IPMI

### DIFF
--- a/phosphor-ipmi-net@.service
+++ b/phosphor-ipmi-net@.service
@@ -4,6 +4,8 @@ Requires=phosphor-ipmi-host.service
 After=phosphor-ipmi-host.service
 
 [Service]
+Environment=IPTABLESRULE=/var/lib/iptables_rules
+ExecStartPre=/usr/bin/env ipmi-net-firewall.sh
 ExecStart=/usr/bin/netipmid -c %i
 SyslogIdentifier=netipmid-%i
 Restart=always


### PR DESCRIPTION
Apply the persistent iptables when network IPMI starts

Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>