### PR TITLE
Enable network IPMI for all network interfaces

### DIFF
--- a/phosphor-ipmi-net@.socket
+++ b/phosphor-ipmi-net@.socket
@@ -1,6 +1,5 @@
 [Socket]
 ListenDatagram=623
-BindToDevice=sys-subsystem-net-devices-%i.device
 
 [Install]
 WantedBy=sockets.target

--- a/sd_event_loop.cpp
+++ b/sd_event_loop.cpp
@@ -84,27 +84,27 @@ int EventLoop::setupSocket(std::shared_ptr<sdbusplus::asio::connection>& bus,
             boost::asio::ip::udp::socket::reuse_address(true));
         udpSocket->bind(ep);
     }
-    // SO_BINDTODEVICE
-    char nameout[IFNAMSIZ];
-    unsigned int lenout = sizeof(nameout);
-    if ((::getsockopt(udpSocket->native_handle(), SOL_SOCKET, SO_BINDTODEVICE,
-                      nameout, &lenout) == -1))
-    {
-        log<level::ERR>("Failed to read bound device",
-                        entry("ERROR=%s", strerror(errno)));
-    }
-    if (iface != nameout && iface != unboundIface)
-    {
-        // SO_BINDTODEVICE
-        if ((::setsockopt(udpSocket->native_handle(), SOL_SOCKET,
-                          SO_BINDTODEVICE, iface.c_str(),
-                          iface.size() + 1) == -1))
-        {
-            log<level::ERR>("Failed to bind to requested interface",
-                            entry("ERROR=%s", strerror(errno)));
-            return EXIT_FAILURE;
-        }
-    }
+//    // SO_BINDTODEVICE
+//    char nameout[IFNAMSIZ];
+//    unsigned int lenout = sizeof(nameout);
+//    if ((::getsockopt(udpSocket->native_handle(), SOL_SOCKET, SO_BINDTODEVICE,
+//                      nameout, &lenout) == -1))
+//    {
+//        log<level::ERR>("Failed to read bound device",
+//                        entry("ERROR=%s", strerror(errno)));
+//    }
+//    if (iface != nameout && iface != unboundIface)
+//    {
+//        // SO_BINDTODEVICE
+//        if ((::setsockopt(udpSocket->native_handle(), SOL_SOCKET,
+//                          SO_BINDTODEVICE, iface.c_str(),
+//                          iface.size() + 1) == -1))
+//        {
+//            log<level::ERR>("Failed to bind to requested interface",
+//                            entry("ERROR=%s", strerror(errno)));
+//            return EXIT_FAILURE;
+//        }
+//    }
     // cannot be constexpr because it gets passed by address
     const int option_enabled = 1;
     // common socket stuff; set options to get packet info (DST addr)


### PR DESCRIPTION
The network IPMI is configured on a per channel basis to meet the requirements
of IPMI specification. The netipmid instance binds to a interface (eg eth0).
When a VLAN interface is created, it is a new interface and there is no netipmid
instance for the VLAN interface.

To workaround this restriction, this patch makes the changes to make the eth0
instance of netipmid listen on *.623. This will cater for the VLAN interfaces.
Since there is only one network interface on Witherspoon. The channel settings
of eth0 are inherited by the VLAN interfaces.

This fix doesn't qualify for upstreaming and it needs to address for cases where
there are multiple interfaces.

Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>