### PR TITLE
Tolerate openssl fips configurations

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -81,6 +81,8 @@ int main(int argc, char* argv[])
     app.add_option("-v,--verbose", verbose, "print more verbose output");
     CLI11_PARSE(app, argc, argv);
 
+    EVP_set_default_properties(NULL, "provider!=fips");
+
     // Connect to system bus
     auto rc = sd_bus_default_system(&bus);
     if (rc < 0)


### PR DESCRIPTION
The IPMI network service is not compliant with the "Security Requirements for Cryptographic Modules" described in Federal Information Processing Standard Publication 140 (FIPS 140).  It uses the HMAC algorithm with a key size below minimum required (64 bits vs 112 bits). This use cannot easily be made compliant.

This change tells OpenSSL to not select any algorithms provided by the fips provider module (while still able to select "fips=yes" algorithms from the default provider).  In this way, the extra checking performed by the fips module's algorithms is avoided.

What is the effect of this?
1. In the default OpenSSL configuration, this has no effect.  Algorithms are selected from the default provider module.
2. In an OpenSSL configuration which loads both the FIPS provider module and the default provider module, the fips provider module is ignored, and algorithms are selected from the default provider module.

Tested:
Tested using OpenSSL version 3.5 (which supports FIPS 140-3) with two configurations:
1. OpenSSL has a default configuration which loads the default provider module.
2. OpenSSL is configured to load the fips and default provider modules and to use fips algorithms by default via default_properties = "fips=yes". In both cases, the service works okay, and users are authenticated via HMAC SHA256 with the smaller key size.